### PR TITLE
fix: mission copy and a set of layout corrections

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -112,9 +112,15 @@ function Navbar() {
             </li>
           </ul>
 
+          {/* The open mobile menu centres on the whole screen, per the design:
+              the items span 226..586 of an 812 frame, which is dead centre.
+              It sits after the 72px header row in the column, so centring on
+              the space that is left would put it 36px low -- hence the full
+              viewport height pulled back up over the header. Desktop is a row
+              in the bar itself and opts out of both. */}
           <ul
             className={`bg-background-white xl:bg-transparent text-baseBlack
-          flex flex-col flex-1 xl:justify-end justify-center items-center xl:gap-1 gap-1.5 xl:py-1.5   py-8  xl:flex-row ${
+          flex flex-col flex-1 h-screen -mt-4.5 xl:h-auto xl:mt-0 xl:justify-end justify-center items-center xl:gap-1 gap-1.5 xl:py-1.5 py-4 xl:flex-row ${
             isOpen ? "block" : "hidden"
           } xl:flex `}
           >

--- a/frontend/src/components/ProjectCard.jsx
+++ b/frontend/src/components/ProjectCard.jsx
@@ -14,6 +14,19 @@ function ProjectCard({ project, className = "" }) {
     navigate(`/projects/${project.ID}`, { state: { project: project } });
   };
 
+  // The panel is a fixed 120: 88 of content inside 16 of padding. One chip row
+  // plus a 16 gap leaves 48, which is the two title lines the design asks for.
+  //
+  // A third theme wraps to a second chip row on a mobile-width card -- the
+  // chips are 104 and only two fit across 288 -- and 56 of chips plus that same
+  // gap would leave 16, half a line, so the title gets cut through the middle.
+  // Tightening the gap to 8 there gives 56 + 8 + 24: exactly one whole line,
+  // clamped to one so the ellipsis lands on it. Desktop cards are wide enough
+  // to keep all three chips on one row, so they keep both.
+  const themes = project["Research Theme"];
+  const themeCount = Array.isArray(themes) ? themes.length : themes ? 1 : 0;
+  const chipsWrap = themeCount >= 3;
+
   return (
     <div
       className={`${className} group flex flex-col rounded-lg border-1 border-baseBlack bg-background-white overflow-hidden cursor-pointer`}
@@ -28,9 +41,19 @@ function ProjectCard({ project, className = "" }) {
       </div>
 
       {/* white panel */}
-      <div className="flex flex-col gap-1 p-1 h-7.5 shrink-0">
-        <ProjectLabelsContainer researchThemes={project["Research Theme"]} />
-        <h2 className="heading4 line-clamp-2">{project["Project Name"]}</h2>
+      <div
+        className={`flex flex-col p-1 h-7.5 shrink-0 ${
+          chipsWrap ? "gap-0.5 xl:gap-1" : "gap-1"
+        }`}
+      >
+        <ProjectLabelsContainer researchThemes={themes} />
+        <h2
+          className={`heading4 shrink-0 ${
+            chipsWrap ? "line-clamp-1 xl:line-clamp-2" : "line-clamp-2"
+          }`}
+        >
+          {project["Project Name"]}
+        </h2>
       </div>
     </div>
   );

--- a/frontend/src/components/PublicationListItem.jsx
+++ b/frontend/src/components/PublicationListItem.jsx
@@ -30,7 +30,7 @@ function PublicationListItem({ publication }) {
           </p>
         </div>
 
-        <div className="flex flex-row gap-1.5">
+        <div className="flex flex-row gap-1 xl:gap-1.5">
           {publication["DOI"] && (
             <a
               href={publication["DOI"]}

--- a/frontend/src/components/modals/JoinModal.jsx
+++ b/frontend/src/components/modals/JoinModal.jsx
@@ -6,7 +6,7 @@ function JoinModal({ onClose }) {
     <>
       <Modal onClose={onClose} backgroundColor="bg-background-tertiaryLight">
         <div className=" xl:w-33 w-full px-1.5 my-10 xl:px-0 flex flex-col gap-2 xl:gap-2">
-          <h2 className="heading2 overflow-wrap hyphens-auto">
+          <h2 className="heading2">
             Looking for opportunities to join us?
           </h2>
           <p className="body">

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -179,10 +179,11 @@ function LandingPage() {
 
           {/* Mission Text, at the same 912 measure as the themes section */}
           <section className="heading3 w-full xl:max-w-narrowBox mx-auto px-1.5 py-4">
-            Our research explores how reality itself - both physical and digital
-            - can be leveraged to understand cognitive, behavioral, and
-            emotional states, assist individuals in their daily lives, and
-            augment human abilities. <br />
+            We study how technology can understand human needs so it can assist and 
+            augment our natural abilities. <br />
+            <br />
+            We’re bridging the gaps between what people want to do and 
+            what their current environment or body allows them to do.<br />
             <br />
             By designing adaptive and empowering technologies, we aim to create
             a world where diverse individuals can thrive, connect, and reach

--- a/frontend/src/pages/ProjectsPage.jsx
+++ b/frontend/src/pages/ProjectsPage.jsx
@@ -58,7 +58,7 @@ function ProjectsPage() {
         />
       </PageTitleSection>
 
-      <div className="pageShell items-start xl:mx-auto">
+      <div className="pageShell items-start xl:mx-auto xl:max-w-narrowBox">
         {!isLoading && shown.length === 0 ? (
           <p className="body">No {section.toLowerCase()} projects to show.</p>
         ) : (

--- a/frontend/src/pages/PublicationsPage.jsx
+++ b/frontend/src/pages/PublicationsPage.jsx
@@ -88,7 +88,7 @@ function PublicationsPage() {
         />
       </PageTitleSection>
 
-      <div className="pageShell items-start xl:mx-auto">
+      <div className="pageShell items-start xl:mx-auto xl:max-w-narrowBox">
         <PublicationsContainer
           publications={shown}
           year={year}


### PR DESCRIPTION
Landing mission copy rewritten.

The join modal title no longer hyphenates. It carried hyphens-auto, which let the browser break a word mid-way and insert a dash; it also carried a bare overflow-wrap, which is not a Tailwind utility and compiled to nothing. That was the only hyphenation in the codebase.

The open mobile menu centres on the screen rather than sitting low. It follows the 72px header row in a column, so centring on the space left over put it exactly 36px below centre; it now spans the viewport and is pulled back up over the header. Its padding drops from 128 to 64 so the 360 of items still clears a 568-tall screen. Items land at 226..586 of an 812 frame, which is what the design draws.

Project cards with three themes no longer cut the title in half. The info panel is a fixed 120 -- 88 of content -- and a third theme wraps to a second chip row on a mobile-width card, so 56 of chips plus the 16 gap left 16px for a 24px line. Those cards tighten the gap to 8 and clamp to a single line, giving 56 + 8 + 24 exactly, with the ellipsis on the line you can actually see. Desktop keeps all three chips on one row and is unchanged.

DOI and PDF sit 16 apart on mobile, 24 on desktop.

The project and publication lists narrow to 912, matching the landing page's publication list. People stays at 1032: its grid is four 240 cards and three 24 gaps, which is exactly 1032.